### PR TITLE
optee: make sure privileged device can be open only once

### DIFF
--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -47,6 +47,8 @@ struct optee_wait_queue {
 };
 
 struct optee_supp {
+	atomic_t available;
+
 	u32 func;
 	u32 ret;
 	size_t num_params;

--- a/drivers/tee/optee/supp.c
+++ b/drivers/tee/optee/supp.c
@@ -23,6 +23,7 @@ void optee_supp_init(struct optee_supp *supp)
 	mutex_init(&supp->supp_mutex);
 	init_completion(&supp->data_to_supp);
 	init_completion(&supp->data_from_supp);
+	atomic_set(&supp->available, 1);
 }
 
 void optee_supp_uninit(struct optee_supp *supp)


### PR DESCRIPTION
Prevents two OP-TEE supplicant processes from running simultaneously.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>