### PR TITLE
include/linux/arm-smccc.h: avoid sign extension problem

### DIFF
--- a/include/linux/arm-smccc.h
+++ b/include/linux/arm-smccc.h
@@ -23,8 +23,9 @@
  * http://infocenter.arm.com/help/topic/com.arm.doc.den0028a/index.html
  */
 
-#define ARM_SMCCC_STD_CALL		0
-#define ARM_SMCCC_FAST_CALL		1
+/* This constant is shifted by 31, make sure it's of an unsigned type */
+#define ARM_SMCCC_STD_CALL		0UL
+#define ARM_SMCCC_FAST_CALL		1UL
 #define ARM_SMCCC_TYPE_SHIFT		31
 
 #define ARM_SMCCC_SMC_32		0


### PR DESCRIPTION
Prior to this patch the ARM_SMCCC_FAST_CALL constant was of an unsigned
type causing unwanted sign extension. This patch explicitly selects an
unsigned type for the constant.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU Aarch64)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Fixes issue https://github.com/linaro-swg/linux/issues/5