### PR TITLE
optee: bugfix error cleanup in optee_probe()

### DIFF
--- a/drivers/tee/optee/core.c
+++ b/drivers/tee/optee/core.c
@@ -500,7 +500,7 @@ err:
 	if (pool)
 		tee_shm_pool_free(pool);
 	if (ioremaped_shm)
-		iounmap(optee->ioremaped_shm);
+		iounmap(ioremaped_shm);
 	return rc;
 }
 


### PR DESCRIPTION
Bugfixes possible null dereference in error cleanup path of
optee_probe().

Reported-by: Zoltan Kuscsik zoltan.kuscsik@linaro.org
Signed-off-by: Jens Wiklander jens.wiklander@linaro.org
