### PR TITLE
arm64: dt: Add OP-TEE firmware to mt8173 **not for mainline**

### DIFF
--- a/arch/arm64/boot/dts/mediatek/mt8173-evb.dts
+++ b/arch/arm64/boot/dts/mediatek/mt8173-evb.dts
@@ -54,6 +54,13 @@
 			};
 		};
 	};
+
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
+	};
 };
 
 &cec {


### PR DESCRIPTION
This patch was missing on after we've update to v4.9 on OP-TEE and it is needed to be able to run OP-TEE on the MTK8173 device.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Reviewed-by: Pascal Brand <pascal.brand@linaro.org>