### PR TITLE
Fix kexec

### DIFF
--- a/drivers/tee/optee/call.c
+++ b/drivers/tee/optee/call.c
@@ -401,7 +401,7 @@ void optee_enable_shm_cache(struct optee *optee)
 }
 
 /**
- * optee_enable_shm_cache() - Disables caching of some shared memory allocation
+ * optee_disable_shm_cache() - Disables caching of some shared memory allocation
  *			      in OP-TEE
  * @optee:	main service struct
  */

--- a/drivers/tee/optee/core.c
+++ b/drivers/tee/optee/core.c
@@ -561,6 +561,16 @@ static const struct of_device_id optee_match[] = {
 	{},
 };
 
+static void optee_shutdown(struct platform_device *pdev)
+{
+	struct optee *optee = platform_get_drvdata(pdev);
+
+	dev_info(&pdev->dev, "%s: informing OP-TEE we are going away\n",
+		 __func__);
+
+	optee_disable_shm_cache(optee);
+}
+
 static struct platform_driver optee_driver = {
 	.driver = {
 		.name = DRIVER_NAME,
@@ -568,6 +578,7 @@ static struct platform_driver optee_driver = {
 	},
 	.probe = optee_probe,
 	.remove = optee_remove,
+	.shutdown = optee_shutdown,
 };
 
 static int __init optee_driver_init(void)


### PR DESCRIPTION
These patches a) fix a cosmetic comment issue and, more importantly, b) allow OP-TEE to continue working after kexec.