### PR TITLE
tee: optee: interruptable rpc sleep

### DIFF
--- a/drivers/tee/optee/rpc.c
+++ b/drivers/tee/optee/rpc.c
@@ -140,11 +140,8 @@ static void handle_rpc_func_cmd_wait(struct optee_msg_arg *arg)
 
 	msec_to_wait = arg->params[0].u.value.a;
 
-	/* set task's state to interruptible sleep */
-	set_current_state(TASK_INTERRUPTIBLE);
-
-	/* take a nap */
-	msleep(msec_to_wait);
+	/* Go to interruptible sleep */
+	msleep_interruptible(msec_to_wait);
 
 	arg->ret = TEEC_SUCCESS;
 	return;


### PR DESCRIPTION
tee: optee: interruptable rpc sleep

Prior to this patch rpc sleep was uninterruptible since msleep() is uninterruptible.
Change to use msleep_interruptible() instead.

Signed-off-by: Tiger Yu  <tigeryu99@hotmail.com>