### PR TITLE
add post-RPC cleanup framework

### DIFF
--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -118,7 +118,14 @@ struct optee_rpc_param {
 	u32	a7;
 };
 
-void optee_handle_rpc(struct tee_context *ctx, struct optee_rpc_param *param);
+struct optee_rpc_deferred_cleanup {
+	struct list_head list_node;
+	void (*clean_cb)(void *arg);
+	void *arg;
+};
+
+struct optee_rpc_deferred_cleanup*
+optee_handle_rpc(struct tee_context *ctx, struct optee_rpc_param *param);
 
 void optee_wait_queue_init(struct optee_wait_queue *wq);
 void optee_wait_queue_exit(struct optee_wait_queue *wq);


### PR DESCRIPTION
RPC handler can provide callback function with argument data.
All those callbacks will be called after end of OP-TEE call.

This allows RPC handlers to allocate resources that can be used during
OP-TEE call and that are needed to be freed afterwards.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

(This feature will be needed for new SHM mechanism)