### PR TITLE
ion: fix unmapped heap test settings **not for mainline**

### DIFF
--- a/drivers/staging/android/ion/Kconfig
+++ b/drivers/staging/android/ion/Kconfig
@@ -64,6 +64,7 @@ config ION_DUMMY_UNMAPPED_HEAP
 config ION_DUMMY_UNMAPPED_BASE
 	hex "Physical base address of the ION unmapped heap"
 	depends on ION_DUMMY_UNMAPPED_HEAP
+	default 0
 	help
 	  Allows one the statically define an unmapped heap from the
 	  ION dummy driver to exercice unamped heaps buffer managment.
@@ -71,6 +72,7 @@ config ION_DUMMY_UNMAPPED_BASE
 config ION_DUMMY_UNMAPPED_SIZE
 	hex "Physical byte size of the ION unmapped heap"
 	depends on ION_DUMMY_UNMAPPED_HEAP
+	default 0
 	help
 	  Allows one the statically define an unmapped heap from the
 	  ION dummy driver to exercice unamped heaps buffer managment.

--- a/drivers/staging/android/ion/ion_dummy_driver.c
+++ b/drivers/staging/android/ion/ion_dummy_driver.c
@@ -56,7 +56,7 @@ static struct ion_platform_heap dummy_heaps[] = {
 			.align	= SZ_16K,
 			.priv	= (void *)(SZ_16K),
 		},
-#ifdef CONFIG_ION_DUMMY_UNMAPPED_HEAP
+#if defined(CONFIG_ION_DUMMY_UNMAPPED_HEAP) && CONFIG_ION_DUMMY_UNMAPPED_SIZE
 		{
 			.id	= ION_HEAP_TYPE_UNMAPPED,
 			.type	= ION_HEAP_TYPE_UNMAPPED,


### PR DESCRIPTION
If one enables ION_DUMMY_UNMAPPED_HEAP without providing the target
unmapped heap configuration settings (physical base address and size),
the kernel cannot build. This situation occurs in linux test build
cases, i.e running the allmodconfig configuration.

This change overcomes the issue by providing default null settings both
ION_DUMMY_UNMAPPED_BASE and ION_DUMMY_UNMAPPED_SIZE.

This change aims at fixing https://projects.linaro.org/browse/SWG-244 (**edited ref**).