### PR TITLE
staging/ion: CONFIG_ION_UNMAPPED_HEAP conditions unmapped heap

### DIFF
--- a/drivers/staging/android/ion/Kconfig
+++ b/drivers/staging/android/ion/Kconfig
@@ -53,9 +53,19 @@ config ION_OF
 
 	  If using Ion and devicetree, you should say Y here
 
+config ION_UNMAPPED_HEAP
+	bool "unmapped heap support in ION"
+	depends on ION && ARM
+	default y
+	help
+	  ION unmapped heap is not available on some architectures.
+	  If unmapped heap is supported, the default configuration enables
+	  it. You should say N here only if you really do not want unmapped
+	  heap support in the ION driver.
+
 config ION_DUMMY_UNMAPPED_HEAP
 	bool "ION dummy driver define an ION unmapped heap"
-	depends on ION_DUMMY
+	depends on ION_DUMMY && ION_UNMAPPED_HEAP
 	help
 	  Dummy ION driver will create a unmapped heap from physical
 	  location provided through CONFIG_ION_DUMMY_UNMAPPED_BASE and

--- a/drivers/staging/android/ion/Makefile
+++ b/drivers/staging/android/ion/Makefile
@@ -1,7 +1,8 @@
 obj-$(CONFIG_ION) +=	ion.o ion-ioctl.o ion_heap.o \
 			ion_page_pool.o ion_system_heap.o \
 			ion_carveout_heap.o ion_chunk_heap.o ion_cma_heap.o
-obj-$(CONFIG_ION) += 	ion_unmapped_heap.o
+
+obj-$(CONFIG_ION_UNMAPPED_HEAP) += ion_unmapped_heap.o
 
 obj-$(CONFIG_ION_TEST) += ion_test.o
 ifdef CONFIG_COMPAT


### PR DESCRIPTION
Condition ION unmapped heap implementation to architectures that
currently support it. ARM is one of these.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>