### PR TITLE
[NEW SHM] tee: optee: remove registered shm size check

### DIFF
--- a/drivers/tee/optee/core.c
+++ b/drivers/tee/optee/core.c
@@ -116,14 +116,6 @@ int optee_from_msg_param(struct tee_param *params, size_t num_params,
 			p->u.memref.shm_offs = mp->u.rmem.offs;
 			p->u.memref.shm = shm;
 
-			/* Check that the memref is covered by the shm object */
-			if (p->u.memref.size) {
-				size_t o = p->u.memref.shm_offs +
-					   p->u.memref.size;
-
-				if (o > tee_shm_get_size(shm))
-					return -EINVAL;
-			}
 			break;
 
 		default:


### PR DESCRIPTION
We don't need to return error if output shm size is larger than
allocated buffer. This is pefrectly fine. In this way TEE or TA
reports that it needs larger buffer (as described in
TEE Client API Specification v1.0, section 3.2.5.).

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

---

This patch fixes issue found at  https://github.com/OP-TEE/optee_os/pull/1830#issuecomment-334801115