### PR TITLE
optee: fix tee-supplicant abort when receive KILLSIG

### DIFF
--- a/drivers/tee/optee/supp.c
+++ b/drivers/tee/optee/supp.c
@@ -88,10 +88,15 @@ u32 optee_supp_thrd_req(struct tee_context *ctx, u32 func, size_t num_params,
 {
 	struct optee *optee = tee_get_drvdata(ctx->teedev);
 	struct optee_supp *supp = &optee->supp;
-	struct optee_supp_req *req = kzalloc(sizeof(*req), GFP_KERNEL);
-	bool interruptable;
+	struct optee_supp_req *req = NULL;
 	u32 ret;
 
+	if (!supp->ctx) {
+		pr_err("There's no tee-supplicant available, please start it\n");
+		return TEEC_ERROR_COMMUNICATION;
+	}
+
+	req = kzalloc(sizeof(*req), GFP_KERNEL);
 	if (!req)
 		return TEEC_ERROR_OUT_OF_MEMORY;
 
@@ -113,34 +118,7 @@ u32 optee_supp_thrd_req(struct tee_context *ctx, u32 func, size_t num_params,
 	 * returned from wait_for_completion(&req->c) successfully we have
 	 * exclusive access again.
 	 */
-	while (wait_for_completion_interruptible(&req->c)) {
-		mutex_lock(&supp->mutex);
-		interruptable = !supp->ctx;
-		if (interruptable) {
-			/*
-			 * There's no supplicant available and since the
-			 * supp->mutex currently is held none can
-			 * become available until the mutex released
-			 * again.
-			 *
-			 * Interrupting an RPC to supplicant is only
-			 * allowed as a way of slightly improving the user
-			 * experience in case the supplicant hasn't been
-			 * started yet. During normal operation the supplicant
-			 * will serve all requests in a timely manner and
-			 * interrupting then wouldn't make sense.
-			 */
-			interruptable = !req->busy;
-			if (!req->busy)
-				list_del(&req->link);
-		}
-		mutex_unlock(&supp->mutex);
-
-		if (interruptable) {
-			req->ret = TEEC_ERROR_COMMUNICATION;
-			break;
-		}
-	}
+	wait_for_completion(&req->c);
 
 	ret = req->ret;
 	kfree(req);


### PR DESCRIPTION
When press ctrl-c to CA, it will receive KILLSIG singal.
And the wait_for_completion_interruptible will always been true.
But actully not tee-supplicant receive KILLSIG, so it become an
endless loop.
To solve this issue:
1)Check whether tee-supplicant is available before create a request.
2)Replace wait_for_completion_interruptible with wait_for_completion.

Signed-off-by: Jianhui Li <airbak.li@hisilicon.com>