### PR TITLE
tee: support of allocating DMA shared buffers

### DIFF
--- a/drivers/tee/optee/optee_msg.h
+++ b/drivers/tee/optee/optee_msg.h
@@ -429,6 +429,8 @@ struct optee_msg_arg {
 #define OPTEE_MSG_RPC_SHM_TYPE_APPL	0
 /* Memory only shared with non-secure kernel */
 #define OPTEE_MSG_RPC_SHM_TYPE_KERNEL	1
+/* Memory shared with non-secure kernel, but exported to userspace */
+#define OPTEE_MSG_RPC_SHM_TYPE_GLOBAL	2
 
 /*
  * Free shared memory previously allocated with OPTEE_MSG_RPC_CMD_SHM_ALLOC

--- a/drivers/tee/optee/rpc.c
+++ b/drivers/tee/optee/rpc.c
@@ -233,6 +233,9 @@ static void handle_rpc_func_cmd_shm_alloc(struct tee_context *ctx,
 	case OPTEE_MSG_RPC_SHM_TYPE_KERNEL:
 		shm = tee_shm_alloc(ctx, sz, TEE_SHM_MAPPED);
 		break;
+	case OPTEE_MSG_RPC_SHM_TYPE_KERNEL_GLOBAL:
+		shm = tee_shm_alloc(ctx, sz, TEE_SHM_MAPPED | TEE_SHM_DMA_BUF);
+		break;
 	default:
 		arg->ret = TEEC_ERROR_BAD_PARAMETERS;
 		return;
@@ -341,6 +344,7 @@ static void handle_rpc_func_cmd_shm_free(struct tee_context *ctx,
 		cmd_free_suppl(ctx, shm);
 		break;
 	case OPTEE_MSG_RPC_SHM_TYPE_KERNEL:
+	case OPTEE_MSG_RPC_SHM_TYPE_GLOBAL:
 		tee_shm_free(shm);
 		break;
 	default:


### PR DESCRIPTION
Add support of allocating DMA shared buffers via RPC calls.

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`