### PR TITLE
security/keys/Kconfig: add KEYS_COMPAT option for keyctl tool

### DIFF
--- a/arch/powerpc/Kconfig
+++ b/arch/powerpc/Kconfig
@@ -1096,11 +1096,6 @@ source "arch/powerpc/Kconfig.debug"
 
 source "security/Kconfig"
 
-config KEYS_COMPAT
-	bool
-	depends on COMPAT && KEYS
-	default y
-
 source "crypto/Kconfig"
 
 config PPC_LIB_RHEAP

--- a/arch/s390/Kconfig
+++ b/arch/s390/Kconfig
@@ -350,9 +350,6 @@ config COMPAT
 config SYSVIPC_COMPAT
 	def_bool y if COMPAT && SYSVIPC
 
-config KEYS_COMPAT
-	def_bool y if COMPAT && KEYS
-
 config SMP
 	def_bool y
 	prompt "Symmetric multi-processing support"

--- a/arch/sparc/Kconfig
+++ b/arch/sparc/Kconfig
@@ -544,9 +544,6 @@ config SYSVIPC_COMPAT
 	depends on COMPAT && SYSVIPC
 	default y
 
-config KEYS_COMPAT
-	def_bool y if COMPAT && KEYS
-
 endmenu
 
 source "net/Kconfig"

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -2701,10 +2701,6 @@ config COMPAT_FOR_U64_ALIGNMENT
 config SYSVIPC_COMPAT
 	def_bool y
 	depends on SYSVIPC
-
-config KEYS_COMPAT
-	def_bool y
-	depends on KEYS
 endif
 
 endmenu

--- a/security/keys/Kconfig
+++ b/security/keys/Kconfig
@@ -20,6 +20,10 @@ config KEYS
 
 	  If you are unsure as to whether this is required, answer N.
 
+config KEYS_COMPAT
+	def_bool y
+	depends on COMPAT && KEYS
+
 config PERSISTENT_KEYRINGS
 	bool "Enable register of persistent per-UID keyrings"
 	depends on KEYS


### PR DESCRIPTION
The Keyctl tool of Raspbian OS doesn't work because Linux kernel of the rpi3
branch doesn't have compat_key functions.

To solve this problem, KEYS_COMPAT option is added to security/keys/Kconfig
file.

Signed-off-by: Seunghun Han <kkamagui@gmail.com>