### PR TITLE
tee: fix unbalanced context refcount in register shm from fd

### DIFF
--- a/drivers/tee/tee_shm.c
+++ b/drivers/tee/tee_shm.c
@@ -372,6 +372,8 @@ struct tee_shm *tee_shm_register_fd(struct tee_context *ctx, int fd)
 	if (!tee_device_get(ctx->teedev))
 		return ERR_PTR(-EINVAL);
 
+	teedev_ctx_get(ctx);
+
 	ref = kzalloc(sizeof(*ref), GFP_KERNEL);
 	if (!ref) {
 		rc = ERR_PTR(-ENOMEM);
@@ -452,6 +454,7 @@ err:
 			dma_buf_put(ref->dmabuf);
 	}
 	kfree(ref);
+	teedev_ctx_put(ctx);
 	tee_device_put(ctx->teedev);
 	return rc;
 }


### PR DESCRIPTION
Successful registration of a memory reference in the scope of a
TEE content must increase the context refcount. This change
adds this missing refcount increase.

The context refcount is already decremented when such shm reference
is freed by its owner, in tee_shm_release().

Fixes: 9f9806e01ee7 ("tee: new ioctl to a register tee_shm from a dmabuf file descriptor")

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>