### PR TITLE
optee: check shm reference are consistent in offset/size

### DIFF
--- a/drivers/tee/tee_core.c
+++ b/drivers/tee/tee_core.c
@@ -284,6 +284,17 @@ static int params_from_user(struct tee_context *ctx, struct tee_param *params,
 			if (IS_ERR(shm))
 				return PTR_ERR(shm);
 
+			/*
+			 * Ensure offset + size does not overflow offset
+			 * and does not overflow the size of the referred
+			 * shared memory object.
+			 */
+			if ((ip.a + ip.b) < ip.a ||
+			    (ip.a + ip.b) > shm->size) {
+				tee_shm_put(shm);
+				return -EINVAL;
+			}
+
 			params[n].u.memref.shm_offs = ip.a;
 			params[n].u.memref.size = ip.b;
 			params[n].u.memref.shm = shm;


### PR DESCRIPTION
This change prevents userland from referencing TEE shared memory
outside the area initially allocated by its owner. Prior this change an
application could not reference or access memory it did not own but
it could reference memory not explicitly allocated by owner but still
allocated to the owner due to the memory allocation granule.

Related to [LHG-283](https://projects.linaro.org/browse/LHG-283?focusedCommentId=57847&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-57847).

Reported-by: Alexandre Jutras <alexandre.jutras@nxp.com>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>