### PR TITLE
tee: support of allocating DMA shared buffers **not for mainline**

### DIFF
--- a/drivers/tee/optee/rpc.c
+++ b/drivers/tee/optee/rpc.c
@@ -233,7 +233,7 @@ static void handle_rpc_func_cmd_shm_alloc(struct tee_context *ctx,
 	case OPTEE_MSG_RPC_SHM_TYPE_KERNEL:
 		shm = tee_shm_alloc(ctx, sz, TEE_SHM_MAPPED);
 		break;
-	case OPTEE_MSG_RPC_SHM_TYPE_KERNEL_GLOBAL:
+	case OPTEE_MSG_RPC_SHM_TYPE_GLOBAL:
 		shm = tee_shm_alloc(ctx, sz, TEE_SHM_MAPPED | TEE_SHM_DMA_BUF);
 		break;
 	default:


### PR DESCRIPTION
Fix compilation issue:
drivers/tee/optee/rpc.c: In function 'handle_rpc_func_cmd_shm_alloc':
drivers/tee/optee/rpc.c:236:7: error: 'OPTEE_MSG_RPC_SHM_TYPE_KERNEL_GLOBAL'
undeclared (first use in this function)
  case OPTEE_MSG_RPC_SHM_TYPE_KERNEL_GLOBAL:

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`