### PR TITLE
arm64: dts: hi3798cv200-poplar: add optee node

### DIFF
--- a/arch/arm64/boot/dts/hisilicon/hi3798cv200-poplar.dts
+++ b/arch/arm64/boot/dts/hisilicon/hi3798cv200-poplar.dts
@@ -6,6 +6,7 @@
  */
 
 /dts-v1/;
+/memreserve/ 0x00000000 0x04080000;
 
 #include <dt-bindings/gpio/gpio.h>
 #include "hi3798cv200.dtsi"

--- a/arch/arm64/boot/dts/hisilicon/hi3798cv200-poplar.dts
+++ b/arch/arm64/boot/dts/hisilicon/hi3798cv200-poplar.dts
@@ -71,6 +71,13 @@
 		gpio = <&gpio6 7 0>;
 		enable-active-high;
 	};
+
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
+	};
 };
 
 &ehci {


### PR DESCRIPTION
```
1. Add OP-TEE node
2. Reserve memory for bootloader purposes

Signed-off-by: Igor Opaniuk <igor.opaniuk@gmail.com>
```