### PR TITLE
Enable Microsoft fTPM driver on Arm Foundation v8 models.

### DIFF
--- a/arch/arm64/boot/dts/arm/foundation-v8.dtsi
+++ b/arch/arm64/boot/dts/arm/foundation-v8.dtsi
@@ -26,6 +26,10 @@
 		serial3 = &v2m_serial3;
 	};
 
+	ftpm {
+	        compatible = "microsoft,ftpm";
+	};
+
 	cpus {
 		#address-cells = <2>;
 		#size-cells = <0>;


### PR DESCRIPTION
Add bindings for Microsoft fTPM driver on Foundation v8 models.

Signed-off-by: Javier Almansa Sobrino <javier.almansasobrino@arm.com>