### PR TITLE
ARM: dts: stm32mp157c-ev1: enable optee node

### DIFF
--- a/arch/arm/boot/dts/stm32mp157c-ev1.dts
+++ b/arch/arm/boot/dts/stm32mp157c-ev1.dts
@@ -372,3 +372,7 @@
 &usbphyc {
 	status = "okay";
 };
+
+&optee {
+	status = "okay";
+};


### PR DESCRIPTION
ARM: dts: stm32mp157c-ev1: enable optee node

The optee device status is disabled by default, change its status to 'okay' in the DTS file of the stm32mp157c-ev1 board
Allow Linux to load the driver handling op-tee execution frame.

Signed-off-by: Timothée Cercueil litchi.pi@protonmail.com
Signed-off-by: Timothée Cercueil timothee.cercueil@st.com