### PR TITLE
arm: dts: define OP-TEE resources for STM32MP1 ED1 and EV1

### DIFF
--- a/arch/arm/boot/dts/stm32mp157c-ed1.dts
+++ b/arch/arm/boot/dts/stm32mp157c-ed1.dts
@@ -70,6 +70,11 @@
 			reg = <0xe8000000 0x8000000>;
 			no-map;
 		};
+
+		optee_memory: optee@fe000000 {
+			reg = <0xfe000000 0x2000000>;
+			no-map;
+		};
 	};
 
 	aliases {
@@ -290,6 +295,10 @@
 	mbox-names = "vq0", "vq1", "shutdown";
 	interrupt-parent = <&exti>;
 	interrupts = <68 1>;
+	status = "okay";
+};
+
+&optee {
 	status = "okay";
 };
 

--- a/arch/arm/boot/dts/stm32mp157c-ev1.dts
+++ b/arch/arm/boot/dts/stm32mp157c-ev1.dts
@@ -372,7 +372,3 @@
 &usbphyc {
 	status = "okay";
 };
-
-&optee {
-	status = "okay";
-};


### PR DESCRIPTION
This change fixes EV1 configuration which lacked OP-TEE
reserved memory. This change also makes ED1 board ready
the host OP-TEE by enabling OP-TEE node and defining the
OP-TEE reserved memory for that board. This change defines
these resources in ED1 DTS file which is included in EV1 DTS
file.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>