### PR TITLE
arm64: dt: OP-TEE for FVP Base RevC

### DIFF
--- a/arch/arm64/boot/dts/arm/fvp-base-revc.dts
+++ b/arch/arm64/boot/dts/arm/fvp-base-revc.dts
@@ -110,6 +110,11 @@
 			reg = <0x00000000 0x18000000 0 0x00800000>;
 			no-map;
 		};
+
+		optee@83000000 {
+			reg = <0x00000000 0x83000000 0 0x01000000>;
+			no-map;
+		};
 	};
 
 	gic: interrupt-controller@2f000000 {
@@ -242,5 +247,12 @@
 				<0 0 42 &gic 0 0 GIC_SPI 42 IRQ_TYPE_LEVEL_HIGH>,
 				<0 0 43 &gic 0 0 GIC_SPI 43 IRQ_TYPE_LEVEL_HIGH>,
 				<0 0 44 &gic 0 0 GIC_SPI 44 IRQ_TYPE_LEVEL_HIGH>;
+	};
+
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
 	};
 };


### PR DESCRIPTION
Configures FVP Base RevC with OP-TEE.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>