### PR TITLE
arm: dts: define OP-TEE resources for STM32MP1 DHCOM/DHCOR SoM's

### DIFF
--- a/arch/arm/boot/dts/stm32mp15xx-dhcom-som.dtsi
+++ b/arch/arm/boot/dts/stm32mp15xx-dhcom-som.dtsi
@@ -61,6 +61,11 @@
 			reg = <0x38000000 0x10000>;
 			no-map;
 		};
+
+		optee_memory: optee@fe000000 {
+			reg = <0xfe000000 0x2000000>;
+			no-map;
+		};
 	};
 
 	ethernet_vio: vioregulator {
@@ -418,6 +423,10 @@
 	mbox-names = "vq0", "vq1", "shutdown";
 	interrupt-parent = <&exti>;
 	interrupts = <68 1>;
+	status = "okay";
+};
+
+&optee {
 	status = "okay";
 };
 

--- a/arch/arm/boot/dts/stm32mp15xx-dhcor-som.dtsi
+++ b/arch/arm/boot/dts/stm32mp15xx-dhcor-som.dtsi
@@ -60,6 +60,11 @@
 			reg = <0x38000000 0x10000>;
 			no-map;
 		};
+
+		optee_memory: optee@fe000000 {
+			reg = <0xfe000000 0x2000000>;
+			no-map;
+		};
 	};
 };
 
@@ -237,6 +242,10 @@
 	mbox-names = "vq0", "vq1", "shutdown";
 	interrupt-parent = <&exti>;
 	interrupts = <68 1>;
+	status = "okay";
+};
+
+&optee {
 	status = "okay";
 };
 


### PR DESCRIPTION
Support for [STM32MP157A-DHCOR-AVENGER96](https://github.com/OP-TEE/build/commit/e43efa5b691a5f594db982134d4116ad1e625412) and [STM32MP157C-DHCOM-PDK2](https://github.com/OP-TEE/build/commit/5914639cb690f57a3ce8ba0277ddc6eea2fc3985) was added in https://github.com/OP-TEE/build, so enable OP-TEE node defined in stm32mp151.dtsi and define memory reserved for OP-TEE for all boards based on STM32MP15 DHCOM/DHCOR SoM's.

I can squash these two commits into a single commit if you wish.