### PR TITLE
arm64: dt: rockpi4: disable node usbdrd_dwc3_0

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
@@ -151,6 +151,24 @@
 		regulator-min-microvolt = <800000>;
 		regulator-max-microvolt = <1400000>;
 	};
+
+       firmware {
+	       optee {
+		       compatible = "linaro,optee-tz";
+		       method = "smc";
+	       };
+       };
+
+       reserved-memory {
+	       #address-cells = <2>;
+	       #size-cells = <2>;
+	       ranges;
+
+	       optee@30000000 {
+		       reg = <0x0 0x30000000 0x0 0x2400000>;
+		       no-map;
+	       };
+       };
 };
 
 &cpu_l0 {

--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
@@ -740,7 +740,7 @@
 };
 
 &usbdrd_dwc3_0 {
-	status = "okay";
+	status = "disabled";
 	dr_mode = "host";
 };
 


### PR DESCRIPTION
If a USB-A to USB-A cable is used to flash the RockPi4 eMMC as described in [1], it is likely that the board will be booted with the cable still plugged into the board and into the computer on the other side. Such a configuration results in periodic error messages from the kernel:

 [    4.832697] usb usb6-port1: Cannot enable. Maybe the USB cable is bad?
 [    4.833416] usb usb6-port1: config error

That is annoying, especially since the messages are also sent to the console by default, which could mess up with CI scripts. Therefore, disable this port (it is the upper USB3 blue port; the lower one will still work fine).

Link: [1] https://wiki.radxa.com/Rockpi4/dev/usb-install
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>